### PR TITLE
feat:添加预览本地cache文件夹下pdf文档功能

### DIFF
--- a/harmony/pdfview/src/main/ets/components/mainpage/RTNPdfView.ets
+++ b/harmony/pdfview/src/main/ets/components/mainpage/RTNPdfView.ets
@@ -90,7 +90,7 @@ export struct RTNPdfView {
     }
   }
 
-  doLoadLocalDocument(filePath: string): void {
+  doLoadLocalDocument(filePath: string, isDelOriginFile: boolean = true): void {
     if (filePath) {
       this.pdfController.loadDocument(filePath)
         .then((res: pdfService.ParseResult) => {
@@ -102,9 +102,12 @@ export struct RTNPdfView {
           Logger.error(`[RTNPdfView]: loadDocument error: ${e.message}`);
         })
         .finally(() => {
-          fs.unlink(filePath).then(() => {
-            Logger.info(`[RTNPdfView]: tempFile deleted`);
-          })
+          Logger.info(`[RTNPdfView]: isDelOriginFile is : ${isDelOriginFile}`)
+          if (isDelOriginFile) {
+            fs.unlink(filePath).then(() => {
+              Logger.info(`[RTNPdfView]: originFile deleted`);
+            })
+          }
         })
     }
   }
@@ -173,12 +176,17 @@ export struct RTNPdfView {
 
   async updateSource() {
     let src: string | undefined = this.descriptor.rawProps.path;
+    Logger.info(`[RTNPdfView]: src is ${src}`);
     if (src) {
-      if (src!.startsWith('asset://')) { // 适配require('../assets/test.pdf')
-        const fileFullPath: string = await this.sendToSandBox(src);
-        this.doLoadLocalDocument(fileFullPath);
-      } else if (src!.startsWith('http://') || src!.startsWith('https://')) {
+      if (src!.startsWith('http://') || src!.startsWith('https://')) {
         this.doLoadHttpDocument(src); // 适配加载在线文件
+      } else {
+        let isDeleteOriginFile: boolean = false;
+        if (src!.startsWith('asset://')) { // 适配require('../assets/test.pdf')
+          src = await this.sendToSandBox(src);
+          isDeleteOriginFile = true;
+        }
+        this.doLoadLocalDocument(src, isDeleteOriginFile); // 适配本地其他目录，比如cache
       }
     }
   }


### PR DESCRIPTION
# Summary
- Close #33 
之前的预览，只支持在线文件和项目资源目录内的文件。本次新增适配，提供加载沙箱内cache目录下文件能力。

## Checklist

- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [X] 更新了 JS/TS 代码 (如有)