### PR TITLE
fix: 替换底层PDF KIT引入方式。不再使用本地har包；添加加载前release处理。

### DIFF
--- a/harmony/pdfview/oh-package.json5
+++ b/harmony/pdfview/oh-package.json5
@@ -6,7 +6,6 @@
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
-    "@rnoh/react-native-openharmony": 'file:../react_native_openharmony',
-    "PDFView": "file:./lib/PDFView.har"
+    "@rnoh/react-native-openharmony": 'file:../react_native_openharmony'
   }
 }

--- a/harmony/pdfview/src/main/ets/components/mainpage/RTNPdfView.ets
+++ b/harmony/pdfview/src/main/ets/components/mainpage/RTNPdfView.ets
@@ -24,16 +24,16 @@
 
 import { Descriptor, ComponentBuilderContext, ViewRawProps, ViewBaseProps } from '@rnoh/react-native-openharmony';
 import { RNOHContext, RNViewBase } from '@rnoh/react-native-openharmony';
-import Logger from '../../Logger';
-import { PDFController, PDFView } from 'PDFView';
-import { pdfService, pdfViewManager } from '@kit.PDFKit';
 import { BusinessError } from '@kit.BasicServicesKit';
-import common from '@ohos.app.ability.common';
 import fs from '@ohos.file.fs';
 import request from '@ohos.request';
 import buffer from '@ohos.buffer';
 import cryptoFramework from '@ohos.security.cryptoFramework';
+import { webview } from '@kit.ArkWeb';
+import { pdfService, pdfViewManager, PdfView } from '@kit.PDFKit'
+import { common } from '@kit.AbilityKit';
 import { ON_PROGRESS_CHANGE } from './types';
+import Logger from '../../Logger';
 
 export const PDF_VIEW_TYPE: string = "RTNPdfView";
 
@@ -60,9 +60,6 @@ export interface PdfViewRawProps extends ViewRawProps {
 
 export type PdfViewDescriptor = Descriptor<'RTNPdfView', ViewBaseProps, PdfViewState, PdfViewRawProps>
 
-let context = getContext(this) as common.UIAbilityContext;
-let filesDir = context.filesDir;
-
 @Component
 export struct RTNPdfView {
   ctx!: RNOHContext;
@@ -74,8 +71,8 @@ export struct RTNPdfView {
   @State controllerStatus: boolean = false;
   private unregisterDescriptorChangesListener?: () => void = undefined;
   private cleanupCommandCallback?: () => void = undefined;
-  private pdfController: PDFController = new PDFController();
-
+  private pdfController: pdfViewManager.PdfController = new pdfViewManager.PdfController();
+  controller: webview.WebviewController = new webview.WebviewController();
   @Builder
   emptyBuild(ctx: ComponentBuilderContext) {
   }
@@ -94,8 +91,8 @@ export struct RTNPdfView {
 
   doLoadLocalDocument(filePath: string, isDelOriginFile: boolean = true): void {
     let initPageIndex: number | undefined = this.descriptor.rawProps.page;
-    let spacing: number | undefined = this.descriptor.rawProps.spacing;
-    let scale: number | undefined = this.descriptor.rawProps.scale;
+    let spacing: number = Number(this.descriptor.rawProps.spacing);
+    let scale: number =  Number(this.descriptor.rawProps.scale);
     let minScale: number | undefined = this.descriptor.rawProps.minScale;
     let maxScale: number | undefined = this.descriptor.rawProps.maxScale;
     let password: string | undefined = this.descriptor.rawProps.password;
@@ -109,6 +106,7 @@ export struct RTNPdfView {
     };
 
     if (filePath) {
+      this.pdfController.releaseDocument();
       this.pdfController.loadDocument(filePath, password, initPageIndex, progressCallBack)
         .then((res: pdfService.ParseResult) => {
           switch (res) {
@@ -184,6 +182,8 @@ export struct RTNPdfView {
   }
 
   async downloadHttpFile(url: string): Promise<string> {
+    let context = getContext(this) as common.UIAbilityContext;
+    let filesDir = context.filesDir;
     const hashFileName: string = await this.processFileName(url);
     const fullFileName: string = filesDir + "/" + hashFileName + '.pdf';
     if (fs.accessSync(fullFileName)) {
@@ -379,7 +379,7 @@ export struct RTNPdfView {
   build() {
     RNViewBase({ ctx: this.ctx, tag: this.tag }) {
       if (this.descriptor.rawProps.path) {
-        PDFView(
+        PdfView(
           {
             controller: this.pdfController,
             pageLayout: pdfService.PageLayout.LAYOUT_SINGLE,


### PR DESCRIPTION
# Summary
- Closes #54
fix: 替换底层PDF KIT引入方式。不再使用本地har包；添加加载前release处理。

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)